### PR TITLE
Fix rendering of blocks with labels

### DIFF
--- a/R/alluvial.R
+++ b/R/alluvial.R
@@ -62,8 +62,10 @@ alluvial <- function( ..., freq, col="gray", border=0, layer, hide=FALSE, alpha=
     x <- cbind(x[-length(x)], x[-1])
     # By how much stripes need to be shifted upwards (gap/max(gap))
     gap <- cumsum( c(0L, diff(as.numeric(d[o,i])) != 0) )
+    mx <- max(gap)
+    if (mx == 0) mx <- 1
     # shifts
-    gap <- gap / max(gap) * w
+    gap <- gap / mx * w
     # add gap-related shifts to stripe coordinates on dimension i
     (x + gap)[order(o),]
   }


### PR DESCRIPTION
If a variable is a 1-level factor, it fails to draw label rectangles. To reproduce the bug try: 

tit <- as.data.frame(Titanic)
tit <- subset(tit, Class == 'Crew')
tit2d <- aggregate( Freq ~ Class + Survived, data=tit, sum);
alluvial( tit2d[,1:2], freq=tit2d$Freq))
