### PR TITLE
use 'hide' column in p rather than raw input to exclude ribbons

### DIFF
--- a/R/alluvial.R
+++ b/R/alluvial.R
@@ -91,7 +91,7 @@ alluvial <- function( ..., freq,
   plot(NULL, type="n", xlim=c(1-cw, np+cw), ylim=c(0, 1), xaxt="n", yaxt="n",
        xaxs="i", yaxs="i", xlab='', ylab='', frame=FALSE)
   # For every stripe
-  ind <- rev(order(p[!hide, ]$layer))
+  ind <- which(!p$hide)[rev(order(p[!p$hide, ]$layer))]
   for(i in ind )
   {
     # For every inter-dimensional segment

--- a/R/alluvial.R
+++ b/R/alluvial.R
@@ -91,7 +91,7 @@ alluvial <- function( ..., freq,
   plot(NULL, type="n", xlim=c(1-cw, np+cw), ylim=c(0, 1), xaxt="n", yaxt="n",
        xaxs="i", yaxs="i", xlab='', ylab='', frame=FALSE)
   # For every stripe
-  ind <- rev(order(p$layer)[!hide])
+  ind <- rev(order(p[!hide, ]$layer))
   for(i in ind )
   {
     # For every inter-dimensional segment


### PR DESCRIPTION
When using `layer` and `hide` together, i noticed that non-standard `layer`s would result in the wrong ribbons being omitted. This was because the `hide` input was being used after invoking `order`. Instead, i've used the `hide` column in `p` before using `order`, which solved the problem in some examples i used. A `check()` produced no errors and the documentation did not change.